### PR TITLE
Add funding-cascade training scripts

### DIFF
--- a/train/funding-cascade/CASCADE_USAGE.md
+++ b/train/funding-cascade/CASCADE_USAGE.md
@@ -1,0 +1,303 @@
+# Funding statement extraction — three-model cascade
+
+A cascade for extracting (and cleaning) the funding-acknowledgment statement from
+the markdown text of an arXiv paper. Outputs either the cleaned funding
+statement string, or an empty string if the paper has no funding info.
+
+Bench: best@0.85 F1 = **0.953**, strict tsr@0.95 F1 = **0.725** on
+`cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test` test split (597 docs).
+
+## Models
+
+All three are CC0 on the Hugging Face Hub:
+
+1. `cometadata/funding-chunk-classifier-modernbert-base` — ModernBERT-base
+   binary classifier, decides which 8K-token chunk of a (potentially very long)
+   paper to look at. Custom architecture (encoder + mean-pool + 1-linear); the
+   repo includes `modeling.py` with the class.
+2. `cometadata/funding-extraction-modernbert-base-spanhead` — ModernBERT-base
+   span head: predicts start/end token indices + a "no-answer" logit on a
+   single chunk. Custom architecture; the repo includes `modeling.py`.
+3. `cometadata/funding-cleaning-qwen3-4b-lora` — Qwen3-4B-Instruct-2507 + LoRA
+   (r=32, attn+MLP only). Takes a "rough span ± context" and rewrites it to
+   match the canonical frontier-labeled form (strips LaTeX markers, joins
+   paragraph breaks).
+
+## Input
+
+The cascade expects the **VLM-converted markdown** of an arXiv PDF (i.e. the
+`vlm_markdown` field in the source dataset). PymuPDF text is too noisy to feed
+in directly. Long docs (> 8K tokens) are fine — stage 1 chunks them.
+
+## Dependencies
+
+```
+pip install "transformers>=4.45,<6" "peft>=0.14" "accelerate" "torch>=2.4" \
+            "huggingface_hub>=0.26" rapidfuzz
+```
+
+Both ModernBERT models also need their custom `modeling.py` from the repo. The
+snippets below grab them via `hf_hub_download`.
+
+## End-to-end usage
+
+```python
+import importlib.util
+import torch
+import torch.nn.functional as F
+from huggingface_hub import hf_hub_download
+from peft import PeftModel
+from transformers import AutoModel, AutoModelForCausalLM, AutoTokenizer
+
+DEVICE = "cuda"
+MAX_TOK = 8192
+STRIDE = 4096
+
+CHUNK_REPO = "cometadata/funding-chunk-classifier-modernbert-base"
+SPAN_REPO  = "cometadata/funding-extraction-modernbert-base-spanhead"
+CLEAN_REPO = "cometadata/funding-cleaning-qwen3-4b-lora"
+MB_BASE    = "answerdotai/ModernBERT-base"
+QWEN_BASE  = "Qwen/Qwen3-4B-Instruct-2507"
+
+
+def _load_class(repo: str, class_name: str):
+    """Fetch modeling.py from an HF repo and import it as a module."""
+    src = hf_hub_download(repo, "modeling.py")
+    spec = importlib.util.spec_from_file_location(f"_{class_name}_mod", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return getattr(mod, class_name)
+
+
+# ----- load the three models once -----
+mb_tok = AutoTokenizer.from_pretrained(MB_BASE)
+
+ChunkClassifier = _load_class(CHUNK_REPO, "ChunkClassifier")
+chunker = ChunkClassifier(MB_BASE).to(DEVICE).eval()
+chunker.load_state_dict(torch.load(
+    hf_hub_download(CHUNK_REPO, "pytorch_model.bin"),
+    map_location=DEVICE, weights_only=True,
+))
+
+SpanHead = _load_class(SPAN_REPO, "SpanHead")
+spanner = SpanHead(MB_BASE).to(DEVICE).eval()
+spanner.load_state_dict(torch.load(
+    hf_hub_download(SPAN_REPO, "pytorch_model.bin"),
+    map_location=DEVICE, weights_only=True,
+))
+
+qwen_tok = AutoTokenizer.from_pretrained(QWEN_BASE)
+cleaner_base = AutoModelForCausalLM.from_pretrained(
+    QWEN_BASE, dtype=torch.bfloat16, device_map=DEVICE
+)
+cleaner = PeftModel.from_pretrained(cleaner_base, CLEAN_REPO).eval()
+
+
+# ----- single-doc extraction -----
+SYSTEM_CLEAN = (
+    "You are a funding statement cleaner. Given a rough extracted funding "
+    "statement and its surrounding context from an academic paper, output "
+    "the exact funding statement as it should appear in a database. Clean "
+    "up LaTeX markers ($^{N}$, \\textsuperscript), hyphenated line breaks, "
+    "and abnormal whitespace, but DO NOT paraphrase. If the rough span is "
+    "not actually a funding statement, output the single word: NONE"
+)
+
+
+@torch.no_grad()
+def extract_funding(vlm_markdown: str) -> str:
+    """Returns the cleaned funding statement, or '' if none."""
+
+    # --- Stage 1: pick the top-2 chunks ---
+    enc = mb_tok(vlm_markdown, add_special_tokens=False,
+                  return_offsets_mapping=True, truncation=False)
+    ids, offsets = enc["input_ids"], enc["offset_mapping"]
+
+    if len(ids) <= MAX_TOK:
+        chunks = [(0, len(ids))]
+    else:
+        chunks = []
+        for st in range(0, len(ids), STRIDE):
+            en = min(st + MAX_TOK, len(ids))
+            chunks.append((st, en))
+            if en == len(ids):
+                break
+
+    chunk_probs = []
+    for st, en in chunks:
+        c_ids = torch.tensor(ids[st:en]).unsqueeze(0).to(DEVICE)
+        c_attn = torch.ones_like(c_ids)
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            logit = chunker(c_ids, c_attn).float()
+        chunk_probs.append((torch.sigmoid(logit).item(), st, en))
+
+    chunk_probs.sort(key=lambda x: -x[0])
+    candidates = [c for c in chunk_probs[:2] if c[0] >= 0.4]
+    if not candidates:
+        return ""  # no funding-likely chunk
+
+    # --- Stage 2: span head on each candidate; pick lowest no-answer prob ---
+    best = None  # (no_a_prob, span_text, char_start, char_end)
+    for _, st, en in candidates:
+        c_offsets = offsets[st:en]
+        c_ids = torch.tensor(ids[st:en]).unsqueeze(0).to(DEVICE)
+        c_attn = torch.ones_like(c_ids)
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            s_log, e_log, na_log = spanner(c_ids, c_attn)
+        s_log = s_log.squeeze(0).float().cpu()
+        e_log = e_log.squeeze(0).float().cpu()
+        no_a = torch.sigmoid(na_log).item()
+        if no_a >= 0.5:
+            continue
+        s = int(s_log.argmax())
+        e = s + int(e_log[s : s + 300].argmax())
+        if not (0 <= s <= e < len(c_offsets)):
+            continue
+        char_s = c_offsets[s][0]
+        char_e = c_offsets[e][1]
+        span_text = vlm_markdown[char_s:char_e].strip()
+        if best is None or no_a < best[0]:
+            best = (no_a, span_text, char_s, char_e)
+
+    if best is None:
+        return ""
+    _, rough_span, char_s, char_e = best
+
+    # --- Stage 3: cleanup LoRA ---
+    ctx_l = vlm_markdown[max(0, char_s - 400) : char_s]
+    ctx_r = vlm_markdown[char_e : char_e + 400]
+    user = f"{ctx_l}<ROUGH>{rough_span}</ROUGH>{ctx_r}"
+    messages = [
+        {"role": "system", "content": SYSTEM_CLEAN},
+        {"role": "user", "content": user},
+    ]
+    prompt_ids = qwen_tok.apply_chat_template(
+        messages, tokenize=True, add_generation_prompt=True, return_tensors="pt"
+    ).to(DEVICE)
+    out = cleaner.generate(prompt_ids, max_new_tokens=512, do_sample=False,
+                            pad_token_id=qwen_tok.eos_token_id)
+    decoded = qwen_tok.decode(
+        out[0, prompt_ids.shape[1]:], skip_special_tokens=True
+    ).strip()
+    if decoded.upper() == "NONE":
+        return ""
+    return decoded
+
+
+# Example
+funding = extract_funding(open("paper.md").read())
+print(funding or "(no funding statement)")
+```
+
+## Stage-by-stage details
+
+### Stage 1 — chunk classifier
+- Outputs a scalar in `[0, 1]` per 8K-token chunk.
+- Decoding: take the top-2 chunks with `prob >= 0.4`. If none, return `""`.
+- Calling convention: mean-pooled binary head, **bfloat16 inference is fine**.
+- Standalone metrics (doc-level binary): F1 = 0.968 at threshold 0.5.
+
+### Stage 2 — span head
+- Outputs three things per chunk: `start_logits[seq]`, `end_logits[seq]`,
+  `no_answer` scalar.
+- Decoding:
+  - If `sigmoid(no_answer) >= 0.5` → this chunk has no funding, skip it.
+  - Else `start = argmax(start_logits)`, `end = start + argmax(end_logits[start:start+300])`.
+  - Convert back to char offsets via the tokenizer's `return_offsets_mapping`.
+- Among the surviving stage-1 chunks, pick the one with the **lowest** no-answer
+  probability (most confident there's funding).
+- Standalone metrics (with stage 1 retrieval): strict tsr@0.95 F1 = 0.722,
+  best@0.85 F1 = 0.956.
+
+### Stage 3 — cleanup LoRA
+- Input format is **load-bearing**: the user message must be
+  `<context_left><ROUGH>rough_span</ROUGH><context_right>`. The `<ROUGH>` tags
+  tell the model what to clean.
+- Use the SYSTEM prompt verbatim (above) — the model was trained on it.
+- Greedy decoding (`do_sample=False`, `temperature=0` equivalent). Max ~512
+  new tokens.
+- Output is **either** the cleaned funding-statement string (verbatim or
+  near-verbatim from the input) **or** the literal token `"NONE"` →
+  interpret as empty.
+
+## Hard ceiling — read this
+
+The training labels were written by frontier models (Claude / GPT) and are
+*not* always verbatim substrings of any source representation:
+
+- ~72% of test gold strings are a verbatim substring of `vlm_markdown`.
+- ~28% are not, due to frontier normalization (joined paragraphs, stripped
+  LaTeX, normalized whitespace, occasional rephrasing).
+
+This **caps any extractive-or-light-cleanup model around strict tsr@0.95 F1
+= 0.73**. The cascade hits 0.725 on strict, essentially at the ceiling.
+
+If you score with `best@0.85` (max of token_sort_ratio, token_set_ratio, and
+both directions of partial_ratio, threshold 0.85 — paraphrase-tolerant), you
+get F1 = 0.953, which is the practical "did we capture the funding info"
+number and is what downstream consumers usually want.
+
+## Failure modes
+
+- **Wrong sibling sentence picked** (~14% of test docs). When an
+  acknowledgments section has multiple funding-like sentences ("R.P
+  acknowledges..." vs "L.V acknowledges..."), the span head can pick the
+  wrong one. The cleanup LoRA cannot recover this — it cleans whatever it's
+  handed.
+- **Cleanup LoRA over-rewrites** (~3% of test docs). The LoRA occasionally
+  prepends an unrelated thanks-sentence from the surrounding context.
+  Mitigation: if you have a downstream verifier, prefer the stage-2 rough
+  span when stage-3 disagrees substantially.
+- **False positives on thanks-only acknowledgments** (~2% of test docs). The
+  chunker fires on "we thank Dr. X" sections that mention no money. If you
+  need to be very precision-conservative, post-filter: emit `""` if the
+  cleaned output contains no funding-indicator words
+  (`grant|funded|supported by|NSF|NIH|ERC|...`).
+
+## Memory / latency rough numbers (single H100 80GB)
+
+- Stage 1: ~50ms per 8K-token chunk
+- Stage 2: ~50ms per 8K-token chunk
+- Stage 3: ~200-500ms per call (~512 output tokens, Qwen3-4B in bf16)
+
+Typical 30-50K-token paper → 6-12 chunks for stage 1, 1-2 for stage 2, 1
+stage-3 call. End-to-end ~1-2s per paper.
+
+## When to skip stages
+
+- **Skip stage 1**: just use the last 8K tokens of the paper as the only
+  chunk. Stage 2 will still work; you lose ~0.5pt F1 (most funding statements
+  are near the end of the paper) but skip the chunker entirely.
+- **Skip stage 3**: if you only need approximate localization (good enough to
+  feed to a regex/LLM downstream), stage 2 output alone is best@0.85 F1
+  0.956. The +0.3pt strict gain from stage 3 may not be worth the 4B-param
+  inference cost in your use case.
+
+## Eval / reproduction
+
+Evaluation uses fuzzy-similarity at multiple thresholds. The scoring code
+lives in this dataset's training repo, but for reproduction:
+
+```python
+from rapidfuzz import fuzz
+
+def best_at_85(gold: str, pred: str) -> bool:
+    if not gold and not pred: return True
+    if not gold or not pred: return False
+    g, p = gold.lower(), pred.lower()
+    s = max(
+        fuzz.token_sort_ratio(g, p),
+        fuzz.token_set_ratio(g, p),
+        fuzz.partial_ratio(g, p),
+        fuzz.partial_ratio(p, g),
+    )
+    return s >= 85.0
+
+def strict_at_95(gold: str, pred: str) -> bool:
+    if not gold and not pred: return True
+    if not gold or not pred: return False
+    return fuzz.token_sort_ratio(gold.lower(), pred.lower()) >= 95.0
+```
+
+A doc is counted as a match if `metric(gold, pred)` is true. F1 is computed at
+the document level over the test split.

--- a/train/funding-cascade/README.md
+++ b/train/funding-cascade/README.md
@@ -1,0 +1,94 @@
+# Funding statement extraction cascade — training code
+
+Training scripts for the three-stage cascade that extracts and cleans
+funding statements from arXiv PDFs. Each stage corresponds to one published
+model:
+
+| Stage | Script | HF model |
+|---|---|---|
+| 1 — chunk classifier | `train_chunk_classifier.py` | [`cometadata/funding-chunk-classifier-modernbert-base`](https://huggingface.co/cometadata/funding-chunk-classifier-modernbert-base) |
+| 2 — span head | `train_span_head.py` | [`cometadata/funding-extraction-modernbert-base-spanhead`](https://huggingface.co/cometadata/funding-extraction-modernbert-base-spanhead) |
+| 3 — cleaning LoRA | `train_cleaning_lora.py` | [`cometadata/funding-cleaning-qwen3-4b-lora`](https://huggingface.co/cometadata/funding-cleaning-qwen3-4b-lora) |
+
+See [`CASCADE_USAGE.md`](./CASCADE_USAGE.md) for the full inference pipeline,
+load-and-run code, and benchmark numbers.
+
+## Setup
+
+```bash
+pip install "torch>=2.4" "transformers>=4.45,<6" "trl>=0.29" "peft>=0.14" \
+            "accelerate" "datasets" "pandas" "rapidfuzz" \
+            "huggingface_hub>=0.26" "tqdm" "wandb"
+```
+
+Each script pulls the training data from
+[`cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test`](https://huggingface.co/datasets/cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test)
+automatically (or accepts `--train-parquet /local/path.parquet` to use a
+cached copy).
+
+Set `HF_TOKEN` and (optionally) `WANDB_API_KEY` env vars before training.
+
+## Stage 1 — chunk classifier
+
+Single 1× H100, ~30 min:
+
+```bash
+python train_chunk_classifier.py \
+    --output-dir checkpoints/chunk-classifier \
+    --epochs 3 --batch-size 2 --grad-accum 8
+```
+
+## Stage 2 — span head
+
+Single 1× H100, ~45 min:
+
+```bash
+python train_span_head.py \
+    --output-dir checkpoints/span-head \
+    --epochs 4 --batch-size 4 --grad-accum 4
+```
+
+## Stage 3 — cleaning LoRA
+
+Single 1× H100, ~1 h (Qwen3-4B + LoRA, bf16, gradient checkpointing):
+
+```bash
+python train_cleaning_lora.py \
+    --output-dir checkpoints/cleaning-lora \
+    --epochs 3 --batch-size 2 --grad-accum 8
+```
+
+Each script's `--help` lists all hyperparameters.
+
+## Output layout
+
+Each script writes:
+
+- `epoch{N}.pt` per epoch (state_dict for stages 1-2, TRL `SFTTrainer`
+  checkpoints for stage 3)
+- A final `pytorch_model.bin` (stages 1-2) or `final/` + `merged/` directories
+  (stage 3)
+- The tokenizer config
+
+For stages 1-2, the saved state dicts load via the model classes defined at
+the top of each script (also bundled as `modeling.py` in the HF repos). For
+stage 3, `final/` is the LoRA adapter and `merged/` is the merged
+full-precision model that vLLM can serve.
+
+## Notes on training-data construction
+
+All three scripts use `align_utils.align_stmt` (verbatim substring first,
+then anchor-based fuzzy alignment via `rapidfuzz.partial_ratio_alignment`) to
+locate the gold funding statement inside `vlm_markdown`. About 28% of gold
+strings are not verbatim substrings (frontier labelers normalize whitespace,
+strip LaTeX markers, occasionally rephrase), so the fuzzy fallback is
+essential — without it ~28% of positive training rows would be dropped.
+
+The cleaning LoRA augments each positive example with two jittered variants
+(`±80` char endpoint noise, snapped to whitespace) to make the model robust
+to upstream span-tagger boundary errors.
+
+## Reproducibility
+
+All scripts accept `--seed` (default 42). Hyperparameters in the per-script
+docstrings match the ones used to train the published models.

--- a/train/funding-cascade/align_utils.py
+++ b/train/funding-cascade/align_utils.py
@@ -1,0 +1,105 @@
+"""Shared utilities: fuzzy span alignment of a gold funding statement into a
+source text representation.
+
+The funding-extraction dataset's gold strings were written by frontier
+labelers and are not always verbatim substrings of the source — labelers
+normalize whitespace, strip LaTeX markers, and occasionally join paragraphs.
+`align_stmt` first tries a verbatim substring match; if that fails it
+performs an anchor-based fuzzy alignment.
+"""
+import re
+from typing import Optional, Tuple
+
+from rapidfuzz import fuzz
+
+
+def find_verbatim(stmt: str, text: str) -> Optional[Tuple[int, int, float]]:
+    idx = text.find(stmt)
+    if idx >= 0:
+        return idx, idx + len(stmt), 100.0
+    return None
+
+
+def find_fuzzy_window(stmt: str, text: str, min_score: float = 75.0
+                       ) -> Optional[Tuple[int, int, float]]:
+    """Anchor + scan: find a window in `text` whose substring best matches stmt."""
+    if not stmt or not text:
+        return None
+    L = len(stmt)
+    tokens = re.findall(r"\w+", stmt)
+    if len(tokens) < 3:
+        return None
+    text_lower = text.lower()
+
+    candidates = []
+
+    # Anchor 1: first 4 tokens
+    anchor = " ".join(tokens[:4]).lower()
+    idx = text_lower.find(anchor)
+    while idx != -1 and len(candidates) < 20:
+        start = max(0, idx - 50)
+        end = min(len(text), idx + L + 100)
+        candidates.append((start, end))
+        idx = text_lower.find(anchor, idx + 1)
+
+    # Anchor 2: last 4 tokens
+    if len(tokens) >= 8:
+        anchor2 = " ".join(tokens[-4:]).lower()
+        idx = text_lower.find(anchor2)
+        while idx != -1 and len(candidates) < 30:
+            start = max(0, idx - L - 100)
+            end = min(len(text), idx + 100)
+            candidates.append((start, end))
+            idx = text_lower.find(anchor2, idx + 1)
+
+    # Anchor 3: distinctive long token (e.g., grant id)
+    long_toks = [t for t in tokens if len(t) >= 8 and t.lower() not in {
+        "supported", "research", "national", "foundation", "university"
+    }]
+    if long_toks and len(candidates) < 20:
+        for lt in long_toks[:3]:
+            lt_l = lt.lower()
+            idx = text_lower.find(lt_l)
+            while idx != -1 and len(candidates) < 30:
+                start = max(0, idx - L // 2)
+                end = min(len(text), idx + L)
+                candidates.append((start, end))
+                idx = text_lower.find(lt_l, idx + 1)
+
+    if not candidates:
+        return None
+
+    best_score = -1
+    best = None
+    for s, e in candidates:
+        snippet = text[s:e]
+        if len(snippet) < L * 0.4:
+            continue
+        score = fuzz.partial_ratio(stmt.lower(), snippet.lower())
+        if score > best_score:
+            best_score = score
+            best = (s, e)
+
+    if best_score < min_score or best is None:
+        return None
+
+    s, e = best
+    snippet = text[s:e]
+    try:
+        align = fuzz.partial_ratio_alignment(stmt.lower(), snippet.lower(),
+                                              score_cutoff=min_score)
+        if align is not None:
+            return (s + align.dest_start, s + align.dest_end, float(align.score))
+    except Exception:
+        pass
+    return (s, e, float(best_score))
+
+
+def align_stmt(stmt: str, text: str) -> Optional[Tuple[int, int, float]]:
+    """Try verbatim substring match first; fall back to fuzzy alignment."""
+    if not stmt or not text:
+        return None
+    v = find_verbatim(stmt, text)
+    if v is not None:
+        return v
+    return find_fuzzy_window(stmt, text)

--- a/train/funding-cascade/train_chunk_classifier.py
+++ b/train/funding-cascade/train_chunk_classifier.py
@@ -1,0 +1,223 @@
+"""Train the stage-1 chunk classifier.
+
+ModernBERT-base + mean-pool + 1-d linear head. Predicts P(chunk contains a
+funding statement) for an 8192-token chunk of an academic paper's
+vlm_markdown.
+
+Trained chunk labels:
+    1 if the gold funding statement (located via verbatim substring or
+      rapidfuzz.partial_ratio_alignment >= 0.7) overlaps the chunk's
+      character range by more than half its length,
+    0 otherwise.
+
+Usage:
+    python train_chunk_classifier.py \\
+        --hf-dataset cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test \\
+        --output-dir checkpoints/chunk-classifier \\
+        --epochs 3
+
+Pushes the corresponding pretrained adapter to HF as
+`cometadata/funding-chunk-classifier-modernbert-base`.
+"""
+import argparse
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import torch
+import torch.nn as nn
+from huggingface_hub import hf_hub_download
+from torch.utils.data import DataLoader, Dataset
+from tqdm import tqdm
+from transformers import AutoModel, AutoTokenizer
+
+from align_utils import align_stmt
+
+
+# ----- model -----
+
+class ChunkClassifier(nn.Module):
+    """ModernBERT encoder + mean-pool + binary head."""
+
+    def __init__(self, base="answerdotai/ModernBERT-base"):
+        super().__init__()
+        self.encoder = AutoModel.from_pretrained(base)
+        self.head = nn.Linear(self.encoder.config.hidden_size, 1)
+
+    def forward(self, input_ids, attention_mask):
+        out = self.encoder(input_ids=input_ids, attention_mask=attention_mask)
+        mask = attention_mask.unsqueeze(-1).float()
+        pooled = (out.last_hidden_state * mask).sum(1) / mask.sum(1).clamp(min=1)
+        return self.head(pooled).squeeze(-1)  # one logit per chunk
+
+
+# ----- data -----
+
+def build_examples(df, tokenizer, max_tokens: int, stride: int):
+    examples = []
+    for _, row in tqdm(df.iterrows(), total=len(df), file=sys.stderr,
+                        desc="chunking"):
+        stmts = list(row["funding_statements"])
+        gold = stmts[0] if stmts else ""
+        text = row["vlm_markdown"]
+        enc = tokenizer(text, return_offsets_mapping=True,
+                        add_special_tokens=False, truncation=False)
+        ids = enc["input_ids"]
+        offsets = enc["offset_mapping"]
+
+        # Locate gold char range in text via verbatim or fuzzy
+        if gold:
+            a = align_stmt(gold, text)
+            cs, ce = (a[0], a[1]) if a is not None else (-1, -1)
+        else:
+            cs, ce = -1, -1
+
+        if len(ids) <= max_tokens:
+            chunk_ranges = [(0, len(ids))]
+        else:
+            chunk_ranges = []
+            for st in range(0, len(ids), stride):
+                en = min(st + max_tokens, len(ids))
+                chunk_ranges.append((st, en))
+                if en == len(ids):
+                    break
+
+        for st, en in chunk_ranges:
+            label = 0
+            if cs >= 0:
+                chunk_char_start = offsets[st][0]
+                chunk_char_end = offsets[en - 1][1]
+                overlap_start = max(cs, chunk_char_start)
+                overlap_end = min(ce, chunk_char_end)
+                overlap = max(0, overlap_end - overlap_start)
+                if overlap > 0.5 * (ce - cs):
+                    label = 1
+            examples.append({"ids": ids[st:en], "label": label})
+    return examples
+
+
+class ChunkDataset(Dataset):
+    def __init__(self, examples):
+        self.examples = examples
+
+    def __len__(self):
+        return len(self.examples)
+
+    def __getitem__(self, i):
+        return self.examples[i]
+
+
+def collate(batch):
+    L = max(len(b["ids"]) for b in batch)
+    ids = torch.zeros(len(batch), L, dtype=torch.long)
+    attn = torch.zeros(len(batch), L, dtype=torch.long)
+    labels = torch.zeros(len(batch), dtype=torch.float32)
+    for i, b in enumerate(batch):
+        n = len(b["ids"])
+        ids[i, :n] = torch.tensor(b["ids"], dtype=torch.long)
+        attn[i, :n] = 1
+        labels[i] = b["label"]
+    return {"input_ids": ids, "attention_mask": attn, "labels": labels}
+
+
+def warmup_cosine(opt, warmup, total):
+    def f(step):
+        if step < warmup:
+            return step / max(1, warmup)
+        prog = (step - warmup) / max(1, total - warmup)
+        return 0.5 * (1 + math.cos(math.pi * prog))
+    return torch.optim.lr_scheduler.LambdaLR(opt, f)
+
+
+def load_train_df(hf_dataset: str, local_parquet: str) -> pd.DataFrame:
+    if local_parquet:
+        return pd.read_parquet(local_parquet)
+    path = hf_hub_download(repo_id=hf_dataset, filename="train.parquet",
+                            repo_type="dataset")
+    return pd.read_parquet(path)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-model", default="answerdotai/ModernBERT-base")
+    ap.add_argument("--hf-dataset",
+                    default="cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test",
+                    help="HF dataset id to pull train.parquet from")
+    ap.add_argument("--train-parquet", default=None,
+                    help="Local train.parquet (overrides --hf-dataset)")
+    ap.add_argument("--output-dir", default="checkpoints/chunk-classifier")
+    ap.add_argument("--max-tokens", type=int, default=8192)
+    ap.add_argument("--stride", type=int, default=4096)
+    ap.add_argument("--batch-size", type=int, default=2)
+    ap.add_argument("--grad-accum", type=int, default=8)
+    ap.add_argument("--epochs", type=int, default=3)
+    ap.add_argument("--lr", type=float, default=5e-5)
+    ap.add_argument("--warmup-steps", type=int, default=20)
+    ap.add_argument("--weight-decay", type=float, default=0.01)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(args.seed)
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model)
+    df = load_train_df(args.hf_dataset, args.train_parquet)
+    examples = build_examples(df, tokenizer, args.max_tokens, args.stride)
+    n_pos = sum(e["label"] for e in examples)
+    print(f"chunks: {len(examples)}, positive: {n_pos}, "
+          f"negative: {len(examples) - n_pos}")
+
+    ds = ChunkDataset(examples)
+    model = ChunkClassifier(args.base_model).to(device)
+
+    pos_weight = torch.tensor(len(examples) / max(n_pos, 1), device=device)
+    loss_fn = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
+
+    steps_per_epoch = (len(ds) + args.batch_size - 1) // args.batch_size
+    opt_steps = (steps_per_epoch + args.grad_accum - 1) // args.grad_accum
+    total = opt_steps * args.epochs
+    optim = torch.optim.AdamW(model.parameters(), lr=args.lr,
+                               weight_decay=args.weight_decay)
+    sched = warmup_cosine(optim, args.warmup_steps, total)
+
+    for epoch in range(args.epochs):
+        model.train()
+        loader = DataLoader(ds, batch_size=args.batch_size, collate_fn=collate,
+                             shuffle=True)
+        pbar = tqdm(loader, total=steps_per_epoch, desc=f"epoch {epoch}",
+                    file=sys.stderr)
+        optim.zero_grad()
+        elosses = []
+        for i, batch in enumerate(pbar):
+            ids = batch["input_ids"].to(device)
+            attn = batch["attention_mask"].to(device)
+            labels = batch["labels"].to(device)
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                logits = model(ids, attn)
+            loss = loss_fn(logits.float(), labels) / args.grad_accum
+            loss.backward()
+            if (i + 1) % args.grad_accum == 0 or (i + 1) == steps_per_epoch:
+                nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+                optim.step()
+                sched.step()
+                optim.zero_grad()
+            elosses.append(loss.item() * args.grad_accum)
+        pbar.close()
+        print(f"epoch {epoch}: mean loss = {sum(elosses)/len(elosses):.4f}")
+        ckpt_path = Path(args.output_dir) / f"epoch{epoch}.pt"
+        torch.save(model.state_dict(), ckpt_path)
+        print(f"  saved {ckpt_path}")
+
+    # Convenience: save last checkpoint as pytorch_model.bin (HF-style)
+    final = Path(args.output_dir) / "pytorch_model.bin"
+    torch.save(model.state_dict(), final)
+    tokenizer.save_pretrained(args.output_dir)
+    print(f"saved final weights + tokenizer to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train/funding-cascade/train_cleaning_lora.py
+++ b/train/funding-cascade/train_cleaning_lora.py
@@ -1,0 +1,228 @@
+"""Train the stage-3 cleanup LoRA.
+
+Qwen3-4B-Instruct-2507 + LoRA (r=32, attn+MLP only — NOT embed/lm_head).
+Trained to map a rough extracted funding-statement span + ±400 char context
+to the frontier-cleaned canonical form (or `NONE` for negatives).
+
+Training data construction (per train doc):
+    - For positives, locate the gold via verbatim or fuzzy alignment in
+      vlm_markdown, jitter both endpoints by uniform ±80 chars snapped to
+      whitespace (simulates upstream span-tagger bound noise). Two jittered
+      variants per gold for augmentation.
+    - For negatives, a random ±400-char window inside vlm_markdown with the
+      <ROUGH> tags around a random 100-300 char interior span; target = NONE.
+
+Usage:
+    python train_cleaning_lora.py \\
+        --hf-dataset cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test \\
+        --output-dir checkpoints/cleaning-lora \\
+        --epochs 3
+
+Pushes as `cometadata/funding-cleaning-qwen3-4b-lora`.
+"""
+import argparse
+import json
+import os
+import random
+import sys
+from pathlib import Path
+
+import pandas as pd
+import torch
+from datasets import Dataset
+from huggingface_hub import hf_hub_download
+from peft import LoraConfig, get_peft_model
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from trl import SFTConfig, SFTTrainer
+
+from align_utils import align_stmt
+
+
+SYSTEM = (
+    "You are a funding statement cleaner. Given a rough extracted funding "
+    "statement and its surrounding context from an academic paper, output "
+    "the exact funding statement as it should appear in a database. Clean "
+    "up LaTeX markers ($^{N}$, \\textsuperscript), hyphenated line breaks, "
+    "and abnormal whitespace, but DO NOT paraphrase. If the rough span is "
+    "not actually a funding statement, output the single word: NONE"
+)
+
+
+def jitter_span_bounds(text: str, cs: int, ce: int, max_chars: int,
+                        rng: random.Random):
+    """Randomly extend/contract span bounds by up to max_chars; snap to whitespace."""
+    def snap_to_ws(p, forward: bool):
+        if not forward:
+            for i in range(p, max(0, p - 30), -1):
+                if i < len(text) and text[i].isspace():
+                    return i + 1
+            return max(0, p)
+        else:
+            for i in range(p, min(len(text), p + 30)):
+                if text[i].isspace():
+                    return i
+            return min(len(text), p)
+    new_cs = cs + rng.randint(-max_chars, max_chars)
+    new_ce = ce + rng.randint(-max_chars, max_chars)
+    new_cs = max(0, min(len(text), new_cs))
+    new_ce = max(new_cs + 30, min(len(text), new_ce))
+    new_cs = snap_to_ws(new_cs, forward=False)
+    new_ce = snap_to_ws(new_ce, forward=True)
+    return new_cs, new_ce
+
+
+def build_example(row, rng: random.Random, jitter_chars: int, context_chars: int):
+    """Build one (system, user, assistant) chat triple from a train row."""
+    vlm = row["vlm_markdown"]
+    stmts = list(row["funding_statements"])
+    if stmts:
+        gold = stmts[0]
+        a = align_stmt(gold, vlm)
+        if a is None:
+            return None
+        cs, ce, _ = a
+        cs_j, ce_j = jitter_span_bounds(vlm, cs, ce, jitter_chars, rng)
+        ctx_start = max(0, cs_j - context_chars)
+        ctx_end = min(len(vlm), ce_j + context_chars)
+        rel_s = cs_j - ctx_start
+        rel_e = ce_j - ctx_start
+        ctx = vlm[ctx_start:ctx_end]
+        marked = ctx[:rel_s] + "<ROUGH>" + ctx[rel_s:rel_e] + "</ROUGH>" + ctx[rel_e:]
+        target = gold
+    else:
+        # Negative: random window + random rough region
+        if len(vlm) < 500:
+            return None
+        ctx_start = rng.randint(0, max(0, len(vlm) - 800))
+        ctx_end = min(len(vlm), ctx_start + 800)
+        rel_s = rng.randint(100, max(200, (ctx_end - ctx_start) // 2))
+        rel_e = min(ctx_end - ctx_start, rel_s + rng.randint(100, 300))
+        ctx = vlm[ctx_start:ctx_end]
+        marked = ctx[:rel_s] + "<ROUGH>" + ctx[rel_s:rel_e] + "</ROUGH>" + ctx[rel_e:]
+        target = "NONE"
+    return {
+        "messages": [
+            {"role": "system", "content": SYSTEM},
+            {"role": "user", "content": marked},
+            {"role": "assistant", "content": target},
+        ]
+    }
+
+
+def load_train_df(hf_dataset: str, local_parquet: str) -> pd.DataFrame:
+    if local_parquet:
+        return pd.read_parquet(local_parquet)
+    path = hf_hub_download(repo_id=hf_dataset, filename="train.parquet",
+                            repo_type="dataset")
+    return pd.read_parquet(path)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-model", default="Qwen/Qwen3-4B-Instruct-2507")
+    ap.add_argument("--hf-dataset",
+                    default="cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test")
+    ap.add_argument("--train-parquet", default=None)
+    ap.add_argument("--output-dir", default="checkpoints/cleaning-lora")
+    ap.add_argument("--epochs", type=int, default=3)
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--batch-size", type=int, default=2)
+    ap.add_argument("--grad-accum", type=int, default=8)
+    ap.add_argument("--max-length", type=int, default=1536)
+    ap.add_argument("--lora-r", type=int, default=32)
+    ap.add_argument("--lora-alpha", type=int, default=64)
+    ap.add_argument("--lora-dropout", type=float, default=0.05)
+    ap.add_argument("--jitter-chars", type=int, default=80,
+                    help="Max char jitter on positive span endpoints")
+    ap.add_argument("--context-chars", type=int, default=400,
+                    help="Chars of context on each side of the rough span")
+    ap.add_argument("--pos-augment-passes", type=int, default=2,
+                    help="How many jittered variants of each positive to sample")
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    df = load_train_df(args.hf_dataset, args.train_parquet)
+    rng = random.Random(args.seed)
+    rows = []
+    n_dropped = 0
+    for _, r in tqdm(df.iterrows(), total=len(df), file=sys.stderr,
+                      desc="building examples"):
+        stmts = list(r["funding_statements"])
+        is_pos = len(stmts) > 0
+        n_passes = args.pos_augment_passes if is_pos else 1
+        for _ in range(n_passes):
+            ex = build_example(r, rng, args.jitter_chars, args.context_chars)
+            if ex is None:
+                n_dropped += 1
+            else:
+                rows.append(ex)
+    print(f"built {len(rows)} examples (dropped {n_dropped} unalignable)")
+    ds = Dataset.from_list(rows)
+
+    base = AutoModelForCausalLM.from_pretrained(
+        args.base_model, dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    base.gradient_checkpointing_enable(
+        gradient_checkpointing_kwargs={"use_reentrant": False}
+    )
+
+    # CRITICAL: LoRA on attn + MLP only — NOT embed_tokens / lm_head.
+    # Including those modules in the LoRA targets caused garbage outputs
+    # in the merged checkpoint during earlier experiments.
+    lcfg = LoraConfig(
+        r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
+        bias="none",
+        task_type="CAUSAL_LM",
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                          "gate_proj", "up_proj", "down_proj"],
+    )
+    model = get_peft_model(base, lcfg)
+
+    cfg = SFTConfig(
+        output_dir=args.output_dir,
+        num_train_epochs=args.epochs,
+        per_device_train_batch_size=args.batch_size,
+        gradient_accumulation_steps=args.grad_accum,
+        learning_rate=args.lr,
+        warmup_ratio=0.05,
+        lr_scheduler_type="cosine",
+        bf16=True,
+        max_length=args.max_length,
+        logging_steps=10,
+        save_strategy="epoch",
+        save_total_limit=2,
+        report_to="wandb" if "WANDB_API_KEY" in os.environ else "none",
+        run_name=os.path.basename(args.output_dir),
+        gradient_checkpointing=True,
+        packing=False,
+        completion_only_loss=True,
+    )
+    trainer = SFTTrainer(model=model, args=cfg, train_dataset=ds,
+                          processing_class=tokenizer)
+    trainer.train()
+
+    final_dir = os.path.join(args.output_dir, "final")
+    trainer.save_model(final_dir)
+    print(f"saved LoRA adapter to {final_dir}")
+
+    merged_dir = os.path.join(args.output_dir, "merged")
+    print(f"merging LoRA into base for vLLM inference...")
+    merged = trainer.model.merge_and_unload()
+    merged.save_pretrained(merged_dir)
+    tokenizer.save_pretrained(merged_dir)
+    print(f"merged checkpoint saved to {merged_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train/funding-cascade/train_span_head.py
+++ b/train/funding-cascade/train_span_head.py
@@ -1,0 +1,270 @@
+"""Train the stage-2 span-extraction head.
+
+ModernBERT-base + linear start head + linear end head + linear no-answer head.
+Predicts (start_token, end_token) of the funding statement within an
+8192-token chunk, plus a no-answer logit indicating whether the chunk
+contains a funding statement at all.
+
+The training chunk for each positive doc is the 8192-token sliding window
+(stride 4096) that contains the gold funding statement; the gold is located
+via verbatim substring or `rapidfuzz.partial_ratio_alignment >= 0.7`. For
+negative docs the training chunk is the last 8192-token window and the
+no-answer label is 1.
+
+Usage:
+    python train_span_head.py \\
+        --hf-dataset cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test \\
+        --output-dir checkpoints/span-head \\
+        --epochs 4
+
+Pushes as `cometadata/funding-extraction-modernbert-base-spanhead`.
+"""
+import argparse
+import math
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from huggingface_hub import hf_hub_download
+from torch.utils.data import DataLoader, Dataset
+from tqdm import tqdm
+from transformers import AutoModel, AutoTokenizer
+
+from align_utils import align_stmt
+
+
+# ----- model -----
+
+class SpanHead(nn.Module):
+    """ModernBERT encoder + start/end/no-answer heads."""
+
+    def __init__(self, base="answerdotai/ModernBERT-base"):
+        super().__init__()
+        self.encoder = AutoModel.from_pretrained(base)
+        h = self.encoder.config.hidden_size
+        self.start_head = nn.Linear(h, 1)
+        self.end_head = nn.Linear(h, 1)
+        self.no_answer_head = nn.Linear(h, 1)
+        self.dropout = nn.Dropout(0.1)
+
+    def forward(self, input_ids, attention_mask):
+        out = self.encoder(input_ids=input_ids, attention_mask=attention_mask)
+        hidden = self.dropout(out.last_hidden_state)
+        start_logits = self.start_head(hidden).squeeze(-1)
+        end_logits = self.end_head(hidden).squeeze(-1)
+        # Mean-pool for no-answer
+        mask = attention_mask.unsqueeze(-1).float()
+        pooled = (out.last_hidden_state * mask).sum(1) / mask.sum(1).clamp(min=1)
+        no_answer = self.no_answer_head(pooled).squeeze(-1)
+        return start_logits, end_logits, no_answer
+
+
+# ----- data -----
+
+def find_best_chunk(text, gold, tokenizer, max_tokens, stride):
+    """Pick the chunk that best contains the gold span.
+
+    Returns (chunk_ids, chunk_offsets, gold_start_tok, gold_end_tok, has_gold).
+    For negatives, takes the last chunk and returns (-1, -1, False).
+    """
+    enc = tokenizer(text, return_offsets_mapping=True,
+                    add_special_tokens=False, truncation=False)
+    ids = enc["input_ids"]
+    offsets = enc["offset_mapping"]
+
+    gold_start_tok = gold_end_tok = -1
+    if gold:
+        a = align_stmt(gold, text)
+        if a is not None:
+            cs, ce, _ = a
+            for i, (s, e) in enumerate(offsets):
+                if e > cs and s < ce:
+                    if gold_start_tok == -1:
+                        gold_start_tok = i
+                    gold_end_tok = i
+
+    if len(ids) <= max_tokens:
+        chunk_ranges = [(0, len(ids))]
+    else:
+        chunk_ranges = []
+        for st in range(0, len(ids), stride):
+            en = min(st + max_tokens, len(ids))
+            chunk_ranges.append((st, en))
+            if en == len(ids):
+                break
+
+    if gold_start_tok < 0:
+        # Negative: use the last chunk
+        st, en = chunk_ranges[-1]
+        return ids[st:en], offsets[st:en], -1, -1, False
+
+    # Positive: prefer chunk fully containing the gold
+    for st, en in chunk_ranges:
+        if gold_start_tok >= st and gold_end_tok < en:
+            return (ids[st:en], offsets[st:en],
+                    gold_start_tok - st, gold_end_tok - st, True)
+    # Fallback: pick chunk with max overlap
+    best = max(chunk_ranges,
+               key=lambda r: min(r[1], gold_end_tok + 1) - max(r[0], gold_start_tok))
+    st, en = best
+    s = max(0, gold_start_tok - st)
+    e = min(en - st - 1, gold_end_tok - st)
+    return ids[st:en], offsets[st:en], s, e, True
+
+
+class SpanDataset(Dataset):
+    def __init__(self, examples):
+        self.examples = examples
+
+    def __len__(self):
+        return len(self.examples)
+
+    def __getitem__(self, i):
+        return self.examples[i]
+
+
+def collate(batch):
+    L = max(len(b["ids"]) for b in batch)
+    ids = torch.zeros(len(batch), L, dtype=torch.long)
+    attn = torch.zeros(len(batch), L, dtype=torch.long)
+    starts = torch.zeros(len(batch), dtype=torch.long)
+    ends = torch.zeros(len(batch), dtype=torch.long)
+    no_answer = torch.zeros(len(batch), dtype=torch.float32)
+    for i, b in enumerate(batch):
+        n = len(b["ids"])
+        ids[i, :n] = torch.tensor(b["ids"], dtype=torch.long)
+        attn[i, :n] = 1
+        starts[i] = b["start"] if b["start"] >= 0 else 0
+        ends[i] = b["end"] if b["end"] >= 0 else 0
+        no_answer[i] = 1.0 if b["start"] < 0 else 0.0
+    return {"input_ids": ids, "attention_mask": attn, "starts": starts,
+            "ends": ends, "no_answer": no_answer}
+
+
+def warmup_cosine(opt, warmup, total):
+    def f(step):
+        if step < warmup:
+            return step / max(1, warmup)
+        prog = (step - warmup) / max(1, total - warmup)
+        return 0.5 * (1 + math.cos(math.pi * prog))
+    return torch.optim.lr_scheduler.LambdaLR(opt, f)
+
+
+def load_train_df(hf_dataset: str, local_parquet: str) -> pd.DataFrame:
+    if local_parquet:
+        return pd.read_parquet(local_parquet)
+    path = hf_hub_download(repo_id=hf_dataset, filename="train.parquet",
+                            repo_type="dataset")
+    return pd.read_parquet(path)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-model", default="answerdotai/ModernBERT-base")
+    ap.add_argument("--hf-dataset",
+                    default="cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test")
+    ap.add_argument("--train-parquet", default=None)
+    ap.add_argument("--output-dir", default="checkpoints/span-head")
+    ap.add_argument("--max-tokens", type=int, default=8192)
+    ap.add_argument("--stride", type=int, default=4096)
+    ap.add_argument("--batch-size", type=int, default=4)
+    ap.add_argument("--grad-accum", type=int, default=4)
+    ap.add_argument("--epochs", type=int, default=4)
+    ap.add_argument("--lr", type=float, default=5e-5)
+    ap.add_argument("--warmup-steps", type=int, default=30)
+    ap.add_argument("--weight-decay", type=float, default=0.01)
+    ap.add_argument("--no-answer-loss-weight", type=float, default=1.0)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(args.seed)
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model)
+    df = load_train_df(args.hf_dataset, args.train_parquet)
+    print(f"building span examples for {len(df)} docs...")
+    examples = []
+    n_pos = n_neg = n_unaligned = 0
+    for _, row in tqdm(df.iterrows(), total=len(df), file=sys.stderr):
+        stmts = list(row["funding_statements"])
+        gold = stmts[0] if stmts else ""
+        ids, offsets, s, e, has_g = find_best_chunk(
+            row["vlm_markdown"], gold, tokenizer, args.max_tokens, args.stride,
+        )
+        if gold and not has_g:
+            n_unaligned += 1
+            continue
+        if has_g:
+            n_pos += 1
+        else:
+            n_neg += 1
+        examples.append({"ids": ids, "start": s, "end": e})
+    print(f"  pos={n_pos} neg={n_neg} unaligned_dropped={n_unaligned} "
+          f"-> {len(examples)} examples")
+
+    ds = SpanDataset(examples)
+    model = SpanHead(args.base_model).to(device)
+
+    steps_per_epoch = (len(ds) + args.batch_size - 1) // args.batch_size
+    opt_steps = (steps_per_epoch + args.grad_accum - 1) // args.grad_accum
+    total = opt_steps * args.epochs
+    optim = torch.optim.AdamW(model.parameters(), lr=args.lr,
+                               weight_decay=args.weight_decay)
+    sched = warmup_cosine(optim, args.warmup_steps, total)
+
+    for epoch in range(args.epochs):
+        model.train()
+        loader = DataLoader(ds, batch_size=args.batch_size, collate_fn=collate,
+                             shuffle=True)
+        pbar = tqdm(loader, total=steps_per_epoch, desc=f"epoch {epoch}",
+                    file=sys.stderr)
+        optim.zero_grad()
+        elosses = []
+        for i, batch in enumerate(pbar):
+            ids = batch["input_ids"].to(device)
+            attn = batch["attention_mask"].to(device)
+            starts = batch["starts"].to(device)
+            ends = batch["ends"].to(device)
+            no_a = batch["no_answer"].to(device)
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                slog, elog, nalog = model(ids, attn)
+            mask = attn.bool()
+            slog = slog.masked_fill(~mask, -1e4)
+            elog = elog.masked_fill(~mask, -1e4)
+            ans_mask = (no_a == 0)
+            if ans_mask.any():
+                start_loss = F.cross_entropy(slog[ans_mask].float(),
+                                              starts[ans_mask], reduction="mean")
+                end_loss = F.cross_entropy(elog[ans_mask].float(),
+                                            ends[ans_mask], reduction="mean")
+            else:
+                start_loss = end_loss = 0.0 * slog.sum()
+            no_answer_loss = F.binary_cross_entropy_with_logits(nalog.float(), no_a)
+            loss = (start_loss + end_loss
+                    + args.no_answer_loss_weight * no_answer_loss) / args.grad_accum
+            loss.backward()
+            if (i + 1) % args.grad_accum == 0 or (i + 1) == steps_per_epoch:
+                nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+                optim.step()
+                sched.step()
+                optim.zero_grad()
+            elosses.append(loss.item() * args.grad_accum)
+        pbar.close()
+        print(f"epoch {epoch}: mean loss = {sum(elosses)/len(elosses):.4f}")
+        ckpt_path = Path(args.output_dir) / f"epoch{epoch}.pt"
+        torch.save(model.state_dict(), ckpt_path)
+        print(f"  saved {ckpt_path}")
+
+    final = Path(args.output_dir) / "pytorch_model.bin"
+    torch.save(model.state_dict(), final)
+    tokenizer.save_pretrained(args.output_dir)
+    print(f"saved final weights + tokenizer to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds train/funding-cascade/ with three training scripts (chunk classifier, span head, cleaning LoRA), a shared alignment util, a per-stage README.md, and CASCADE_USAGE.md (end-to-end inference walkthrough).

Each script pulls training data from cometadata/arxiv-pdf-only-works-funding-statement-extraction-train-test automatically. Hyperparameters in each script's docstring match the published models on HF (funding-chunk-classifier-modernbert-base, funding-extraction-modernbert-base-spanhead, funding-cleaning-qwen3-4b-lora).